### PR TITLE
Rotating the symmetries

### DIFF
--- a/determineor.m
+++ b/determineor.m
@@ -10,7 +10,7 @@ symmetry1_string = symmetries{1}.mineral;
 fcc2bcc_KS = (orientation('map',Miller(1,1,1,symmetries{2}),Miller(0,1,1,symmetries{1}),Miller(-1,0,1,symmetries{2}),Miller(-1,-1,1,symmetries{1})));
 
 % Symmetry order correction according to Morito et al.:
-cs_symmetries = symmetries{1}.properGroup;
+cs_symmetries = symmetries{1}.properGroup.rot;
 
 symrots_true(1,1) = cs_symmetries(1);
 symrots_true(2,1) = cs_symmetries(21);

--- a/recaus.m
+++ b/recaus.m
@@ -3,7 +3,7 @@ function [ebsd_aus,devis] = recaus(ebsd_aus,grains,symmetries,fcc2bcc,ib)
 %   Detailed explanation goes here
 
 % Symmetry order correction according to Morito et al.:
-cs_symmetries = symmetries{1}.properGroup;
+cs_symmetries = symmetries{1}.properGroup.rot;
 
 symrots_true(1,1) = cs_symmetries(1);
 symrots_true(2,1) = cs_symmetries(21);


### PR DESCRIPTION
Hi,  
when running PAG_GUI with the latest version of MTEX and Matlab @mikaasbe and I found that in order for the scripts to work as before, we needed to rotate the symmetries before rearranging them.

I've included a fix for this in both `determineor.m` and `recaus.m`.

If this is not because of version differences, and instead because of user error, do you have any idea of what we're doing worng?